### PR TITLE
chore: add strict mode to prevent compilation with warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,8 @@ depends = "$auto,git"
 structopt = "0.3"
 enum_dispatch = "0.3.7"
 
+[features]
+default = ["strict"]
+strict = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![cfg_attr(feature = "strict", deny(warnings))]
 use enum_dispatch::enum_dispatch;
 use std::env;
 use std::fmt;


### PR DESCRIPTION
This patch adds a feature called `strict` to the crate, enabled by default, which will prevent compilation when there are warnings.

Feel free to close this patch without merging. I have found this feature to be helpful as the project grows in complexity, but you'll know your project better than I do.